### PR TITLE
fix: "Error: not implemented [ERROR]   at Transform._transform" (readable-stream)

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const path = require('path');
 const replaceExt = require('replace-ext');
 const PluginError = require('plugin-error');
 const applySourceMap = require('vinyl-sourcemaps-apply');
-const { Transform } = require('readable-stream');
+const { Transform } = require('stream');
 
 function replaceExtension(fp) {
   return path.extname(fp) ? replaceExt(fp, '.js') : fp;


### PR DESCRIPTION
I've got

```
Error: not implemented
[ERROR]   at Transform._transform (/var/lib/jenkins/jobs/Build and Deploy Test/workspace/flo-front/src/main/websources/node_modules/readable-stream/lib/_stream_transform.js:159:9)
```
because of the readable-stream.
I'm not sure what's the reason here, but changing it to 'stream' package solved the issue. Inspired by [gulp-esbuild](https://github.com/ym-project/gulp-esbuild/blob/master/index.js) (btw another "super-fast" transpiler :) )